### PR TITLE
Using redis URL instead of a net.Addr

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ The only dependencies are Go distribution and [Redis](http://redis.io).
 ## Usage
 
 ```go
-redisAddr, _ := net.ResolveTCPAddr("tcp", ":6379")
-te, err := too.New(redisAddr, "movies")
+te, err := too.New("redis://localhost", "movies")
 if err != nil {
 	log.Fatal(err)
 }

--- a/engine.go
+++ b/engine.go
@@ -2,11 +2,7 @@
 
 package too
 
-import (
-	"net"
-
-	"github.com/garyburd/redigo/redis"
-)
+import "github.com/garyburd/redigo/redis"
 
 type Engine struct {
 	c     redis.Conn
@@ -20,8 +16,8 @@ type Engine struct {
 }
 
 // New returns a new engine for given class connected to Redis server at addr.
-func New(addr net.Addr, class string) (*Engine, error) {
-	c, err := redis.Dial(addr.Network(), addr.String())
+func New(url, class string) (*Engine, error) {
+	c, err := redis.DialURL(url)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With my commit is easie create a too engine

``` go
// old way
redisAddr, _ := net.ResolveTCPAddr("tcp", ":6379")
te, err := too.New(redisAddr, "movies")

// new way 
te, err := too.New("redis://localhost:6379", "movies")
```

Because now we can use URL following http://www.iana.org/assignments/uri-schemes/prov/redis spec, so now we can change de redis database, and **use authenticated redis service**. Now is possible to use too in service like Heroku and because we can config too using env `REDIS_URL` 
